### PR TITLE
fix(test): remove unnecessary assignment

### DIFF
--- a/test/integration-test.js
+++ b/test/integration-test.js
@@ -355,7 +355,7 @@ tap.test('concatenating routers fails on shared targets', assert => {
   })
 
   assert.throws(() => {
-    const routes = lhs.concat(rhs)
+    lhs.concat(rhs)
   })
   try {
     lhs.concat(rhs)


### PR DESCRIPTION
this fixes the standard error that is making travis fail right now:
https://travis-ci.org/chrisdickinson/reverse/builds/280876116#L974