### PR TITLE
fix(routes): normalize non-reserved path chars

### DIFF
--- a/lib/router.js
+++ b/lib/router.js
@@ -66,7 +66,32 @@ module.exports = class Router {
   }
 }
 
+/**
+ * Lifted from Hapi: https://github.com/hapijs/call/blob/master/lib/index.js#L157
+ * Thank you, Eran
+ */
+
+function normalize (path) {
+  if (path && path.indexOf('%') !== -1) {
+    // Uppercase %encoded values
+
+    const uppercase = path.replace(/%[0-9a-fA-F][0-9a-fA-F]/g, (encoded) => encoded.toUpperCase())
+
+    // Decode non-reserved path characters: a-z A-Z 0-9 _!$&'()*+,;=:@-.~
+    // ! (%21) $ (%24) & (%26) ' (%27) ( (%28) ) (%29) * (%2A) + (%2B) , (%2C) - (%2D) . (%2E)
+    // 0-9 (%30-39) : (%3A) ; (%3B) = (%3D)
+    // @ (%40) A-Z (%41-5A) _ (%5F) a-z (%61-7A) ~ (%7E)
+
+    const decoded = uppercase.replace(/%(?:2[146-9A-E]|3[\dABD]|4[\dA-F]|5[\dAF]|6[1-9A-F]|7[\dAE])/g, (encoded) => String.fromCharCode(parseInt(encoded.substring(1), 16)))
+
+    path = decoded
+  }
+
+  return path
+}
+
 function match (router, method, route, lastMatch) {
+  route = normalize(route)
   for (const target of router) {
     if (!target.accepts(method)) {
       continue

--- a/test/integration-test.js
+++ b/test/integration-test.js
@@ -364,3 +364,17 @@ tap.test('concatenating routers fails on shared targets', assert => {
   }
   assert.end()
 })
+
+tap.test('normalizes non-reserved path characters', assert => {
+  const router = reverse`
+    GET /~ greet
+  `({
+    greet () {
+    }
+  })
+
+  // note the trailing slash!
+  const result = router.match('GET', '/%7E')
+  assert.ok(result.context, 'Making sure that the result exists')
+  assert.end()
+})


### PR DESCRIPTION
~ for example, is a valid url character, that is escaped by Firefox (and
potentially other browsers, during link clicks. This leads to paths not
matching when they are virtually equivalent (and the URL standard says
they're the same)

Paired with @aearly