### PR TITLE
perf: remove tgt.chomp(); reserve context Map arg

### DIFF
--- a/lib/router.js
+++ b/lib/router.js
@@ -95,34 +95,20 @@ function match (router, method, route, lastMatch) {
     if (!target.accepts(method)) {
       continue
     }
-    const context = target.match(route)
-    if (!context) {
+    const tuple = target.match(route)
+    if (!tuple) {
       continue
     }
-
+    const [context, rest] = tuple
     const value = router.controller[target.name]
-
-    if (typeof value === 'function' || !value) {
-      // if we're pointed at a function, we have to consume
-      // _all_ of the rest of the route for it to match.
-      if (target.chomp(route) !== '') {
-        continue
-      }
-      if (!value) {
-        throw new Error(`expected controller to provide ${target.name}`)
-      }
-      return new Match(
-        router.controller,
-        target.name,
-        context,
-        lastMatch
-      )
+    if (!rest && !value) {
+      throw new Error(`expected controller to provide ${target.name}`)
     }
 
     if (value && value[IS_ROUTER_SYM]) {
       // if there's nothing left of the path, pretend
       // it's a slash so we can pick up nested / routes
-      const remainingPath = target.chomp(route) || '/'
+      const remainingPath = rest || '/'
       const result = match(
         value,
         method,
@@ -137,7 +123,15 @@ function match (router, method, route, lastMatch) {
       if (result) {
         return result
       }
-      continue
+    } else if (!rest) {
+      // if we're pointed at a function, we have to consume
+      // _all_ of the rest of the route for it to match.
+      return new Match(
+        router.controller,
+        target.name,
+        context,
+        lastMatch
+      )
     }
   }
   return null

--- a/lib/target.js
+++ b/lib/target.js
@@ -11,7 +11,7 @@ module.exports = class Target {
     this.expectCount = this.params.reduce((acc, xs) => {
       return acc + xs.groupCount
     }, 0)
-    this.output = this.params.map(xs => null)
+    this.output = this.params.map(xs => [xs.name, null])
     this.regex = routeToRegExp(this.route)
     this.name = target
   }
@@ -23,37 +23,28 @@ module.exports = class Target {
     return this.method === method
   }
 
-  chomp (route) {
-    return route.replace(this.regex, '')
-  }
-
   match (route) {
     const result = this.regex.exec(route)
     if (!result) {
       return
     }
-    result.shift()
-    if (result.length !== this.expectCount) {
+    if (result.length !== this.expectCount + 1) {
       return
     }
     for (var i = 0, j = 0; i < this.params.length; ++i) {
       const coerced = this.params[i].validate(
-        querystring.unescape(result[j])
+        querystring.unescape(result[j + 1])
       )
       if (coerced.error) {
         return
       }
-      this.output[i] = coerced.value
+      this.output[i][1] = coerced.value
       j += this.params[i].groupCount
     }
 
-    const context = new Map()
     // if we've made it all the way through and all parameters are
     // valid, *then* contribute to the context
-    for (var k = 0; k < this.params.length; ++k) {
-      context.set(this.params[k].name, this.output[k])
-    }
-    return context
+    return [new Map(this.output), route.slice(result[0].length)]
   }
 }
 


### PR DESCRIPTION
This reduces the number of `Map#set` calls on a valid match & reduces the amount of garbage objects we create on a valid match.